### PR TITLE
Add build stage GitHub Action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,20 @@
+name: Go
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Build
+      run: make build 


### PR DESCRIPTION
Here is the build stage for GitHub Action.
You will see that the build will fail, but according to this [issue](https://github.com/codegangsta/gin/issues/154) and this [PR](https://github.com/codegangsta/gin/pull/155), the dependency will not be updated.

Maybe you can fork _gin_ to fix it or replace this dependency.