### PR TITLE
fix go vet usage in githooks/pre-commit

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -16,12 +16,12 @@ do
   if [[ $? == 1 ]]; then
     PASS=false
   fi
-
-  go vet $FILE
-  if [[ $? != 0 ]]; then
-    PASS=false
-  fi
 done
+
+go vet ./...
+if [[ $? != 0 ]]; then
+  PASS=false
+fi
 
 if ! $PASS; then
   printf "COMMIT FAILED\n"

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,3 @@ require (
 	go.uber.org/multierr v1.2.0 // indirect
 	go.uber.org/zap v1.10.0
 )
-
-replace gopkg.in/urfave/cli.v1 => github.com/urfave/cli v1.21.0


### PR DESCRIPTION
pre-commit prevent me from commit。

```
git ci -m "init from boilerplate"
# command-line-arguments
vet: pkg/http/rest/handler_test.go:13:13: undeclared name: CreateHandler
# command-line-arguments
vet: pkg/http/rest/middleware/jsonresponse_test.go:16:9: undeclared name: Middleware
# command-line-arguments
vet: pkg/http/rest/middleware/logging_test.go:22:9: undeclared name: Middleware
# command-line-arguments
vet: pkg/http/rest/middleware/middleware_test.go:12:8: undeclared name: CreateMiddleware
COMMIT FAILED
```

after some google，related issue: https://github.com/golang/go/issues/23916

as suggestion "To run vet on a single file, use go tool vet.", i run "go tool vet", but it seems not work any more。

```
$go tool vet pkg/http/rest/middleware/jsonresponse_test.go
vet: invoking "go tool vet" directly is unsupported; use "go vet"
$go version
go version go1.13 darwin/amd64
```

so i use 'go vet ./...'